### PR TITLE
Add shellcheck to CI (refs #1)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,8 +27,32 @@ jobs:
     - name: Install shellcheck
       run: sudo apt-get update && sudo apt-get install -y shellcheck
 
-    - name: Lint shell scripts
-      run: shellcheck install.sh build.sh
+    - name: Find and lint shell scripts
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Lint every tracked shell script in the repo, regardless of directory:
+        #   - any file with a known shell extension
+        #   - any file whose first line is a shell shebang (sh/bash/dash/ksh/zsh)
+        # Using `git ls-files` keeps us scoped to tracked content and naturally
+        # picks up newly added or renamed scripts on the PR that introduces them.
+        mapfile -t scripts < <(
+          {
+            git ls-files -- '*.sh' '*.bash' '*.ksh' '*.zsh'
+            while IFS= read -r f; do
+              [ -f "$f" ] || continue
+              IFS= read -r first <"$f" 2>/dev/null || continue
+              [[ "$first" =~ ^#!.*sh([[:space:]]|$) ]] && printf '%s\n' "$f"
+            done < <(git ls-files)
+          } | sort -u
+        )
+        if [ "${#scripts[@]}" -eq 0 ]; then
+          echo "No shell scripts found."
+          exit 0
+        fi
+        printf 'Linting %d shell script(s):\n' "${#scripts[@]}"
+        printf '  %s\n' "${scripts[@]}"
+        shellcheck -- "${scripts[@]}"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,18 @@ permissions:
   pull-requests: read
 
 jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install shellcheck
+      run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+    - name: Lint shell scripts
+      run: shellcheck install.sh build.sh
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 go vet
 
 # Build
-GIT_COMMIT="$(git rev-parse --short $(git rev-list -1 HEAD))"
+GIT_COMMIT="$(git rev-parse --short "$(git rev-list -1 HEAD)")"
 GIT_TAG="$(git tag --points-at HEAD)"
 GO_VERSION="$(go version | cut -d' ' -f3)"
 BUILD_DATE="$(date --utc)"


### PR DESCRIPTION
## Summary

- Adds a `shellcheck` job to `.github/workflows/go.yml` that runs on every PR (and push to `main`).
- The job **discovers shell scripts dynamically** rather than hard-coding paths — newly added or renamed scripts get linted automatically without further workflow changes, regardless of which directory they live in.
- Fixes the one finding shellcheck reports today: SC2046 in `build.sh`, an unquoted command substitution nested inside `git rev-parse --short`. Quoting the inner `$(git rev-list -1 HEAD)` resolves the warning so the new job is green from the start.

Refs #1.

## Discovery approach

shellcheck has no built-in recursive / directory-scan option (`shellcheck --help` confirms `FILES...` is a hard requirement), so discovery is done externally. The step uses `git ls-files`, which has two nice properties:

1. It only enumerates tracked files — no scanning into `.git/`, vendored deps, or local untracked artifacts.
2. New or renamed scripts appear in `git ls-files` output on the PR that introduces them, so they get linted on that same PR with no manual update to the workflow.

Two predicates feed into the script list, then deduped via `sort -u`:

- Any file matching `*.sh` / `*.bash` / `*.ksh` / `*.zsh`.
- Any file whose first line matches `^#!.*sh([[:space:]]|$)` — covers `#!/bin/sh`, `#!/bin/bash`, `#!/usr/bin/env bash`, `#!/bin/dash -x`, `#!/bin/zsh`, etc., catching scripts without a conventional extension.

Tested locally on this branch: discovers `build.sh` and `install.sh`, shellcheck exits 0.

## Scope note

This is the **belt-and-suspenders** half of the test plan posted on #1, not the load-bearing test. shellcheck doesn't model curl's flag semantics, so it does **not** catch the specific `curl -L -o <URL>` bug from that issue. A behavioral test — running the download step against a local HTTP fixture in CI and asserting that a `ussher` binary file actually lands in cwd — is still needed to cover #1 directly. That belongs in a separate PR.

What this PR does buy us: cheap, automatic coverage for the broader class of shell-script bugs (unquoted expansions, `[[` vs `[`, dead code, missing `--` separators, etc.) for *every* shell script in the repo, now and in the future.

## Test plan

- [x] Discovery snippet picks up `install.sh` and `build.sh` locally.
- [x] `shellcheck` exits 0 against the discovered set.
- [x] `./build.sh` still runs end-to-end and `GIT_COMMIT` is populated correctly after the SC2046 fix (tests pass, `--version` prints expected commit SHA).
- [ ] CI run on the PR shows the new `shellcheck` job passing alongside the existing `build` job.
- [ ] Future regression test: a follow-up PR that adds a script anywhere under the repo (with or without a `.sh` extension, as long as it has a shell shebang) is automatically linted with no further workflow changes.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47