### PR TITLE
Simplify shellcheck discovery to .sh only (review feedback from #6)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,31 +28,14 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y shellcheck
 
     - name: Find and lint shell scripts
-      shell: bash
       run: |
         set -euo pipefail
-        # Lint every tracked shell script in the repo, regardless of directory:
-        #   - any file with a known shell extension
-        #   - any file whose first line is a shell shebang (sh/bash/dash/ksh/zsh)
-        # Using `git ls-files` keeps us scoped to tracked content and naturally
-        # picks up newly added or renamed scripts on the PR that introduces them.
-        mapfile -t scripts < <(
-          {
-            git ls-files -- '*.sh' '*.bash' '*.ksh' '*.zsh'
-            while IFS= read -r f; do
-              [ -f "$f" ] || continue
-              IFS= read -r first <"$f" 2>/dev/null || continue
-              [[ "$first" =~ ^#!.*sh([[:space:]]|$) ]] && printf '%s\n' "$f"
-            done < <(git ls-files)
-          } | sort -u
-        )
-        if [ "${#scripts[@]}" -eq 0 ]; then
-          echo "No shell scripts found."
-          exit 0
-        fi
-        printf 'Linting %d shell script(s):\n' "${#scripts[@]}"
-        printf '  %s\n' "${scripts[@]}"
-        shellcheck -- "${scripts[@]}"
+        # Lint every tracked .sh file, regardless of directory. `git ls-files`
+        # keeps us scoped to tracked content and picks up newly added or
+        # renamed scripts on the PR that introduces them.
+        echo "Discovered shell scripts:"
+        git ls-files -- '*.sh' | sed 's/^/  /'
+        git ls-files -z -- '*.sh' | xargs -0 -r shellcheck --
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,6 @@ jobs:
         # Lint every tracked .sh file, regardless of directory. `git ls-files`
         # keeps us scoped to tracked content and picks up newly added or
         # renamed scripts on the PR that introduces them.
-        echo "Discovered shell scripts:"
         git ls-files -- '*.sh' | sed 's/^/  /'
         git ls-files -z -- '*.sh' | xargs -0 -r shellcheck --
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,6 @@ jobs:
         # Lint every tracked .sh file, regardless of directory. `git ls-files`
         # keeps us scoped to tracked content and picks up newly added or
         # renamed scripts on the PR that introduces them.
-        git ls-files -- '*.sh' | sed 's/^/  /'
         git ls-files -z -- '*.sh' | xargs -0 -r shellcheck --
 
   build:


### PR DESCRIPTION
## Summary

Addresses the review comment on #6 (https://github.com/dolph/ussher/pull/6#discussion_r3144275373):

> We can safely assume all shell files in this repo are `.sh`

Drops the multi-extension glob (`*.bash`, `*.ksh`, `*.zsh`) and the shebang-scan fallback. Replaces the bash-specific `mapfile` + read loop with a one-liner: `git ls-files '*.sh' | xargs -0 -r shellcheck`. The `-r` (no-run-if-empty) flag handles the empty case without an explicit guard.

The behavior the previous version was designed to preserve is unchanged: scripts in any subdirectory are still picked up, and newly added or renamed `.sh` files are linted automatically on the PR that introduces them — that property comes from `git ls-files`, not from the extension list.

## Diff

```diff
-    - name: Find and lint shell scripts
-      shell: bash
-      run: |
-        set -euo pipefail
-        # ...22 lines of mapfile + shebang detection...
-        shellcheck -- "${scripts[@]}"
+    - name: Find and lint shell scripts
+      run: |
+        set -euo pipefail
+        echo "Discovered shell scripts:"
+        git ls-files -- '*.sh' | sed 's/^/  /'
+        git ls-files -z -- '*.sh' | xargs -0 -r shellcheck --
```

Net `-23 +6` lines.

## Test plan

- [x] Locally: discovers `build.sh` and `install.sh`, `shellcheck` exits 0.
- [ ] CI run on the PR shows the new (shorter) `shellcheck` step passing.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47

---
_Generated by [Claude Code](https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47)_