### PR TITLE
Add configurable cache TTL so revoked keys stop authenticating (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ sources:
 - url: https://github.com/dolph.keys
 ```
 
+### `cache_ttl`
+
+Responses from each source URL are cached on disk under `/var/cache/ussher` so that frequent SSH attempts don't hammer the upstream. Cached entries expire after `cache_ttl`; once expired, the next login refetches the source. After `cache_ttl` elapses, key revocations on the upstream propagate to this host. Smaller values mean revocations take effect sooner and add upstream load; larger values reduce upstream load and lengthen the window during which a revoked key could still authenticate.
+
+`cache_ttl` accepts any duration string understood by Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) — for example `30s`, `5m`, `1h`. The default when unset is `5m`.
+
+```yaml
+cache_ttl: 5m
+sources:
+- url: https://github.com/dolph.keys
+```
+
 ## Troubleshooting
 
 ### `Refusing to run unnecessarily writable binary`

--- a/cache.go
+++ b/cache.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"io"
 	"log"
+	"strconv"
+	"time"
 
 	"github.com/peterbourgon/diskv"
 )
@@ -25,24 +27,41 @@ func NewCache(basePath string) *Cache {
 	}
 }
 
-func (c *Cache) Get(key string) (value []byte, ok bool) {
+// Get returns the cached value for key along with the time it was written.
+// The caller is responsible for deciding whether setAt is recent enough to
+// trust. ok is false on a cache miss or on any read/parse error.
+func (c *Cache) Get(key string) (value []byte, setAt time.Time, ok bool) {
 	filename := keyToFilename(key)
 	if filename == "" {
 		log.Printf("Skipping unusable cache: %v", filename)
-		return []byte{}, false
+		return nil, time.Time{}, false
 	}
-	value, err := c.d.Read(filename)
+	raw, err := c.d.Read(filename)
 	if err != nil {
 		log.Print("Cache MISS: ", key)
-		return []byte{}, false
+		return nil, time.Time{}, false
+	}
+	nl := bytes.IndexByte(raw, '\n')
+	if nl < 0 {
+		log.Print("Cache MISS (no header): ", key)
+		return nil, time.Time{}, false
+	}
+	ts, err := strconv.ParseInt(string(raw[:nl]), 10, 64)
+	if err != nil {
+		log.Print("Cache MISS (bad header): ", key)
+		return nil, time.Time{}, false
 	}
 	log.Print("Cache HIT: ", key)
-	return value, true
+	return raw[nl+1:], time.Unix(ts, 0), true
 }
 
 func (c *Cache) Set(key string, value []byte) {
 	filename := keyToFilename(key)
-	if err := c.d.WriteStream(filename, bytes.NewReader(value), true); err != nil {
+	// Prepend a unix-timestamp header line so Get can report write time and
+	// callers can enforce their own freshness policy.
+	header := []byte(strconv.FormatInt(time.Now().Unix(), 10) + "\n")
+	payload := append(header, value...)
+	if err := c.d.WriteStream(filename, bytes.NewReader(payload), true); err != nil {
 		log.Printf("Failed to write %v to cache: %v", key, err)
 		return
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -5,10 +5,10 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestCache(t *testing.T) {
-	// Create a temporary directory for the cache
 	tempDir, err := ioutil.TempDir("", "cache-test")
 	if err != nil {
 		t.Fatal("Failed to create temporary directory for cache:", err)
@@ -20,30 +20,28 @@ func TestCache(t *testing.T) {
 	testKey := "test_key"
 	testValue := []byte("test_value")
 
-	// Test the Get method on an empty cache
-	value, ok := cache.Get(testKey)
-	if ok {
+	if _, _, ok := cache.Get(testKey); ok {
 		t.Error("Expected cache miss, got cache hit")
 	}
 
-	// Test the Set method
+	before := time.Now().Add(-time.Second)
 	cache.Set(testKey, testValue)
+	after := time.Now().Add(time.Second)
 
-	// Test the Get method after setting a value
-	value, ok = cache.Get(testKey)
+	value, setAt, ok := cache.Get(testKey)
 	if !ok {
-		t.Error("Expected cache hit, got cache miss")
+		t.Fatal("Expected cache hit, got cache miss")
 	}
 	if !bytes.Equal(value, testValue) {
 		t.Errorf("Expected value %q, got %q", testValue, value)
 	}
+	if setAt.Before(before) || setAt.After(after) {
+		t.Errorf("setAt %v not in [%v, %v]", setAt, before, after)
+	}
 
-	// Test the Delete method
 	cache.Delete(testKey)
 
-	// Test the Get method after deleting a value
-	value, ok = cache.Get(testKey)
-	if ok {
-		t.Error("Expected cache miss, got cache hit")
+	if _, _, ok := cache.Get(testKey); ok {
+		t.Error("Expected cache miss after delete, got cache hit")
 	}
 }

--- a/cmd.go
+++ b/cmd.go
@@ -8,7 +8,7 @@ import (
 func Run(c *Config) {
 	var wg sync.WaitGroup
 
-	client := NewHTTPClient()
+	client := NewHTTPClient(c.ResolveCacheTTL())
 	keyChan := make(chan []string)
 	for _, source := range c.Sources {
 		wg.Add(1)

--- a/config.go
+++ b/config.go
@@ -3,9 +3,12 @@ package main
 import (
 	"log"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
+
+const defaultCacheTTL = 5 * time.Minute
 
 type GithubEnterprise struct {
 	Hostname string `yaml:"api_hostname"`
@@ -18,7 +21,24 @@ type Source struct {
 }
 
 type Config struct {
-	Sources []Source `yaml:"sources"`
+	// CacheTTL is parsed by time.ParseDuration ("5m", "30s", "1h"). An empty
+	// or unparseable value falls back to defaultCacheTTL.
+	CacheTTL string   `yaml:"cache_ttl"`
+	Sources  []Source `yaml:"sources"`
+}
+
+// ResolveCacheTTL returns the configured cache TTL, falling back to a sane
+// default when unset or malformed.
+func (c *Config) ResolveCacheTTL() time.Duration {
+	if c.CacheTTL == "" {
+		return defaultCacheTTL
+	}
+	d, err := time.ParseDuration(c.CacheTTL)
+	if err != nil {
+		log.Printf("Invalid cache_ttl %q, falling back to %s: %v", c.CacheTTL, defaultCacheTTL, err)
+		return defaultCacheTTL
+	}
+	return d
 }
 
 func (c *Config) LoadConfigByUser(username string) {

--- a/config_test.go
+++ b/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func createTempConfig(t *testing.T, content string) (string, func()) {
@@ -71,5 +72,47 @@ sources:
 
 	if len(config.Sources) != 0 {
 		t.Errorf("Expected 0 sources, got %d: %v", len(config.Sources), config.Sources[0])
+	}
+}
+
+func TestResolveCacheTTL(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{"empty falls back to default", "", defaultCacheTTL},
+		{"unparseable falls back to default", "five minutes", defaultCacheTTL},
+		{"valid seconds", "30s", 30 * time.Second},
+		{"valid minutes", "10m", 10 * time.Minute},
+		{"valid hours", "1h", time.Hour},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{CacheTTL: tc.raw}
+			if got := c.ResolveCacheTTL(); got != tc.want {
+				t.Errorf("ResolveCacheTTL() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfigLoadCacheTTL(t *testing.T) {
+	yamlContent := `
+cache_ttl: 15m
+sources:
+- url: https://example.com/keys
+`
+	tmpFile, cleanup := createTempConfig(t, yamlContent)
+	defer cleanup()
+
+	config := &Config{}
+	config.LoadConfigByPath(tmpFile)
+
+	if config.CacheTTL != "15m" {
+		t.Errorf("Expected CacheTTL %q, got %q", "15m", config.CacheTTL)
+	}
+	if got := config.ResolveCacheTTL(); got != 15*time.Minute {
+		t.Errorf("ResolveCacheTTL() = %v, want %v", got, 15*time.Minute)
 	}
 }

--- a/httpclient.go
+++ b/httpclient.go
@@ -9,22 +9,31 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type Client struct {
 	http  *http.Client
 	cache *Cache
+	ttl   time.Duration
 }
 
-func NewHTTPClient() *Client {
+func NewHTTPClient(ttl time.Duration) *Client {
 	return &Client{
 		http:  &http.Client{},
 		cache: NewCache("/var/cache/ussher"),
+		ttl:   ttl,
 	}
 }
 
+// fresh reports whether a cached entry written at setAt is still within the
+// configured TTL.
+func (c *Client) fresh(setAt time.Time) bool {
+	return time.Since(setAt) < c.ttl
+}
+
 func (c *Client) GetURL(url string) []string {
-	if cached, ok := c.cache.Get(url); ok {
+	if cached, setAt, ok := c.cache.Get(url); ok && c.fresh(setAt) {
 		return bodyToKeys(cached)
 	}
 
@@ -57,7 +66,7 @@ func (c *Client) GetGHE(ghe GithubEnterprise) []string {
 	url := "https://" + ghe.Hostname + "/users/" + ghe.Username + "/keys"
 
 	/* This will cache responses regardless of the token in context here, which could be a security risk. */
-	if cached, ok := c.cache.Get(url); ok {
+	if cached, setAt, ok := c.cache.Get(url); ok && c.fresh(setAt) {
 		var keys []GHEKey
 		err := json.Unmarshal(cached, &keys)
 		if err != nil {


### PR DESCRIPTION
Closes #3.

## Summary

Adds a configurable cache TTL so that key revocations on upstream sources actually propagate to hosts running ussher. Previously the disk cache at `/var/cache/ussher` had no expiry — once a URL's response was cached, every subsequent login returned it indefinitely, which meant a user removing a compromised key from `github.com/<user>.keys` had no way to make the revocation take effect without manually clearing the cache directory on every host.

## Approach

- **`cache.go`** stamps each entry with a unix-timestamp header line on write. `Cache.Get` now returns `(value, setAt, ok)` and leaves the *freshness policy* to the caller. The cache itself stays a dumb byte store; this keeps the new behavior testable in isolation and avoids tangling cache storage with TTL semantics.
- **`config.go`** exposes a new `cache_ttl` field parsed by `time.ParseDuration` ("30s", "5m", "1h"). `Config.ResolveCacheTTL()` returns the parsed value, or the default if unset / unparseable.
- **`httpclient.go`** carries the configured TTL on `Client` and treats a cache hit older than the TTL as a miss (refetches and overwrites). Both `GetURL` and `GetGHE` use the same `fresh(setAt)` helper.
- **`cmd.go`** passes `c.ResolveCacheTTL()` into `NewHTTPClient`.

### Default

`5m`. Trades a small amount of upstream load against a short window in which a revoked key could still authenticate. Operators wanting tighter or looser bounds can tune it per-user.

### Backward compatibility

Existing cache files written by older versions don't have the timestamp header. `Cache.Get` treats those as cache misses (`Cache MISS (no header)`) and the next fetch overwrites them with the new format. No manual `/var/cache/ussher` wipe is required on upgrade.

## Config example

```yaml
cache_ttl: 5m
sources:
- url: https://github.com/dolph.keys
```

README updated with a `cache_ttl` section explaining the trade-off and pointing at `time.ParseDuration`.

## Test plan

- [x] `./build.sh` green: `go vet`, build, `go test -cover` all pass; coverage up from 18.8% → 23.7%.
- [x] New tests:
  - `TestCache` — Get/Set round-trip including assertion that `setAt` is within `[before, after]` bounds around the `Set` call; cache miss after `Delete`.
  - `TestResolveCacheTTL` — table-driven: empty / unparseable fall back to default; valid `30s` / `10m` / `1h` parse correctly.
  - `TestConfigLoadCacheTTL` — `cache_ttl: 15m` round-trips through YAML and resolves to `15 * time.Minute`.
- [x] Existing `TestCache`, `TestConfigLoad`, `TestIsValidUser` still pass.
- [ ] CI shellcheck + build jobs both green on the PR.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47

---
_Generated by [Claude Code](https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47)_