### PR TITLE
Stop killing the process on HTTP fetch errors (closes #2)

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -38,9 +38,9 @@ func (c *Client) GetURL(url string) []string {
 	}
 
 	log.Printf("GET %v", url)
-	resp, err := http.Get(url)
+	resp, err := c.http.Get(url)
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("Failed to fetch %v: %v", url, err)
 		return make([]string, 0)
 	}
 	defer resp.Body.Close()
@@ -48,12 +48,13 @@ func (c *Client) GetURL(url string) []string {
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Fatal(err)
+			log.Printf("Failed to read response body from %v: %v", url, err)
 			return make([]string, 0)
 		}
 		c.cache.Set(url, bodyBytes)
 		return bodyToKeys(bodyBytes)
 	}
+	log.Printf("HTTP %d from %v", resp.StatusCode, url)
 	return make([]string, 0)
 }
 
@@ -78,7 +79,7 @@ func (c *Client) GetGHE(ghe GithubEnterprise) []string {
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Fatal("Unable to create new request", err)
+		log.Printf("Failed to build request for %v: %v", url, err)
 		return make([]string, 0)
 	}
 
@@ -89,7 +90,7 @@ func (c *Client) GetGHE(ghe GithubEnterprise) []string {
 	log.Printf("GET %v", url)
 	resp, err := c.http.Do(req)
 	if err != nil {
-		log.Fatal("Request failed", err)
+		log.Printf("Failed to fetch %v: %v", url, err)
 		return make([]string, 0)
 	}
 	defer resp.Body.Close()
@@ -97,7 +98,7 @@ func (c *Client) GetGHE(ghe GithubEnterprise) []string {
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Fatal(err)
+			log.Printf("Failed to read response body from %v: %v", url, err)
 			return make([]string, 0)
 		}
 		c.cache.Set(url, bodyBytes)
@@ -108,9 +109,8 @@ func (c *Client) GetGHE(ghe GithubEnterprise) []string {
 		}
 
 		return GHEKeysToKeys(keys)
-	} else {
-		log.Fatal("HTTP ", resp.StatusCode, ": ", url)
 	}
+	log.Printf("HTTP %d from %v", resp.StatusCode, url)
 	return make([]string, 0)
 }
 

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+// newTestClient builds a Client wired to a caller-supplied http.Client and a
+// fresh temp cache directory. Returns the client plus a cleanup func.
+func newTestClient(t *testing.T, httpClient *http.Client) (*Client, func()) {
+	t.Helper()
+	tmpDir, err := ioutil.TempDir("", "httpclient-test")
+	if err != nil {
+		t.Fatal("temp dir:", err)
+	}
+	c := &Client{
+		http:  httpClient,
+		cache: NewCache(tmpDir),
+		ttl:   time.Minute,
+	}
+	return c, func() { os.RemoveAll(tmpDir) }
+}
+
+func TestGetURL_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ssh-rsa AAAA alice\nssh-ed25519 BBBB bob\n")
+	}))
+	defer srv.Close()
+
+	c, cleanup := newTestClient(t, srv.Client())
+	defer cleanup()
+
+	keys := c.GetURL(srv.URL)
+	if len(keys) != 2 {
+		t.Fatalf("want 2 keys, got %d: %v", len(keys), keys)
+	}
+	if keys[0] != "ssh-rsa AAAA alice" || keys[1] != "ssh-ed25519 BBBB bob" {
+		t.Errorf("unexpected keys: %v", keys)
+	}
+}
+
+func TestGetURL_5xxIsNotFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c, cleanup := newTestClient(t, srv.Client())
+	defer cleanup()
+
+	keys := c.GetURL(srv.URL)
+	if len(keys) != 0 {
+		t.Errorf("want empty slice on 5xx, got %v", keys)
+	}
+}
+
+func TestGetURL_BodyReadErrorIsNotFatal(t *testing.T) {
+	// Hijack the connection and close it after writing only headers, so the
+	// client gets an error while reading the body.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server does not support hijacking")
+		}
+		conn, bw, err := hj.Hijack()
+		if err != nil {
+			t.Fatal("hijack:", err)
+		}
+		// 200 with a Content-Length larger than what we'll actually send,
+		// then close the connection so io.ReadAll returns an unexpected EOF.
+		fmt.Fprint(bw, "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n")
+		bw.Flush()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	c, cleanup := newTestClient(t, srv.Client())
+	defer cleanup()
+
+	keys := c.GetURL(srv.URL)
+	if len(keys) != 0 {
+		t.Errorf("want empty slice on body read error, got %v", keys)
+	}
+}
+
+func TestGetURL_UnreachableIsNotFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	// Close before the request — the URL points at a no-longer-listening port.
+	srv.Close()
+
+	c, cleanup := newTestClient(t, &http.Client{Timeout: 2 * time.Second})
+	defer cleanup()
+
+	keys := c.GetURL(url)
+	if len(keys) != 0 {
+		t.Errorf("want empty slice on unreachable host, got %v", keys)
+	}
+}
+
+func TestGetGHE_UnreachableIsNotFatal(t *testing.T) {
+	c, cleanup := newTestClient(t, &http.Client{Timeout: 2 * time.Second})
+	defer cleanup()
+
+	// example.invalid is reserved and guaranteed to not resolve, exercising
+	// GetGHE's transport-error path. Pre-fix this would log.Fatal and kill
+	// the test process.
+	keys := c.GetGHE(GithubEnterprise{
+		Hostname: "example.invalid",
+		Username: "alice",
+		Token:    "irrelevant",
+	})
+	if len(keys) != 0 {
+		t.Errorf("want empty slice on unreachable GHE host, got %v", keys)
+	}
+}


### PR DESCRIPTION
Closes #2.

## Summary

`GetURL` and `GetGHE` called `log.Fatal` on every fetch error path: transport errors, body-read errors, and (for `GetGHE`) non-2xx responses. `cmd.go:Run` fans out one goroutine per source so a transient blip on one URL shouldn't block the others — but `log.Fatal` calls `os.Exit(1)` from *inside* the goroutine, killing the whole process and dropping keys already produced by every other healthy source. With the cache TTL added in #8, the network is consulted more often, so the blast radius of this bug grew.

This PR replaces each fatal site with a logged warning + `return make([]string, 0)`. The per-source channel in `cmd.go` already aggregates results, so a failed source quietly contributes zero keys instead of taking the whole login down with it.

## Behavior changes

| Before | After |
|---|---|
| `GetURL` transport error → `os.Exit(1)` | logged, returns `[]` |
| `GetURL` body read error → `os.Exit(1)` | logged, returns `[]` |
| `GetGHE` `http.NewRequest` error → `os.Exit(1)` | logged, returns `[]` |
| `GetGHE` transport error → `os.Exit(1)` | logged, returns `[]` |
| `GetGHE` body read error → `os.Exit(1)` | logged, returns `[]` |
| `GetGHE` non-2xx → `os.Exit(1)` | logged, returns `[]` (now matches `GetURL`) |

Drive-by: `GetURL` switched from the package-level `http.Get(url)` to `c.http.Get(url)` so the `http.Client` already on the struct is actually used, and so tests can inject a custom transport. No external behavior change from this part — `&http.Client{}` was already being constructed in `NewHTTPClient` and was previously dead.

No request headers are logged on errors, to avoid leaking the GHE token.

## Tests

Adds `httpclient_test.go` (~120 lines) with `httptest`-backed coverage for each former fatal path:

- `TestGetURL_Success` — happy path, two keys parsed.
- `TestGetURL_5xxIsNotFatal` — server returns 500.
- `TestGetURL_BodyReadErrorIsNotFatal` — handler hijacks the connection and closes mid-stream so `io.ReadAll` returns `unexpected EOF`.
- `TestGetURL_UnreachableIsNotFatal` — points the client at a closed test server's URL, exercising the transport-error path.
- `TestGetGHE_UnreachableIsNotFatal` — `example.invalid` (RFC 6761 reserved) → DNS NXDOMAIN, exercising `GetGHE`'s transport-error path.

Each test implicitly doubles as regression coverage for the `log.Fatal` removal: if any fatal had been left in place, the test process would `os.Exit(1)` and we'd see no `PASS` line for that test. All five pass.

Coverage: 23.7% → **39.5%**.

## Out of scope

**Stale-on-error fallback.** When a refresh fails, falling back to the expired cached value would preserve availability under transient blips — last-known-good keys keep authenticating until the upstream comes back. That's a policy change on top of this surgical fix and arguably deserves its own discussion. Worth a follow-up issue.

## Test plan

- [x] `./build.sh` green; coverage 39.5%.
- [x] `grep 'log\.Fatal' httpclient.go` returns nothing.
- [x] All five new tests pass; pre-existing tests still pass.
- [ ] CI shellcheck + build jobs both green on the PR.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47

---
_Generated by [Claude Code](https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47)_