### PR TITLE
Publish sha256 alongside the release binary and verify on install (closes #12, #1)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,9 +49,15 @@ jobs:
     - name: Build & Test
       run: ./build.sh
 
+    - name: Generate checksum
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: sha256sum ussher > ussher.sha256
+
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/v')
       with:
         body_path: README.md
-        files: ussher
+        files: |
+          ussher
+          ussher.sha256

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ When `~/.ssh/authorized_keys` does not contain the keys required to authenticate
 
 ## Recommended installation & usage
 
-1. Download the latest release of `ussher` from [github.com/dolph/ussher](https://github.com/dolph/ussher/releases/latest).
+1. Download the latest release of `ussher` from [github.com/dolph/ussher](https://github.com/dolph/ussher/releases/latest), along with its `sha256` checksum, and verify the binary before installing:
+
+   ```bash
+   curl -fLO https://github.com/dolph/ussher/releases/latest/download/ussher
+   curl -fLO https://github.com/dolph/ussher/releases/latest/download/ussher.sha256
+   sha256sum -c ussher.sha256
+   ```
+
+   `sha256sum -c` exits non-zero if the binary doesn't match the published checksum. Don't proceed past this step on a mismatch.
 
 2. Create a dedicated user and group to run `ussher`, named `ussher`:
 

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-# Download the latest binary if one does not exist locally
+# Download the latest binary if one does not exist locally, and verify it
+# against the published sha256 before doing anything with the bytes.
 if ! [ -f ussher ]; then
-    curl -L -o https://github.com/dolph/ussher/releases/latest/download/ussher
+    curl -fLO https://github.com/dolph/ussher/releases/latest/download/ussher
+    curl -fLO https://github.com/dolph/ussher/releases/latest/download/ussher.sha256
+    sha256sum -c ussher.sha256
 fi
 
 # Create a user if one does not exist


### PR DESCRIPTION
Closes #12.
Closes #1.

## Summary

Publishes a `sha256` of the release binary as a release asset, and has `install.sh` (and the README quickstart) verify the binary against that checksum before doing anything with the bytes. Also fixes the long-standing `curl` bug from #1 — `curl -L -o https://...` was missing its filename, so the documented install path didn't actually work.

This is **Tier A** from the issue body. Tier B (`.goreleaser.yml` for cross-compile + Cosign signatures) is a strictly bigger scope conversation that pairs with #15; left as a follow-up.

## Changes

### `.github/workflows/go.yml`

New step before the release upload, gated on the same tag predicate, plus the new file in `files:`:

```yaml
- name: Generate checksum
  if: startsWith(github.ref, 'refs/tags/v')
  run: sha256sum ussher > ussher.sha256

- name: Release
  uses: softprops/action-gh-release@v1
  if: startsWith(github.ref, 'refs/tags/v')
  with:
    body_path: README.md
    files: |
      ussher
      ussher.sha256
```

### `install.sh`

Download block rewritten end-to-end:

```bash
if ! [ -f ussher ]; then
    curl -fLO https://github.com/dolph/ussher/releases/latest/download/ussher
    curl -fLO https://github.com/dolph/ussher/releases/latest/download/ussher.sha256
    sha256sum -c ussher.sha256
fi
```

This single block fixes three things:

- **#1**: the broken `-o` syntax (`-O` derives the filename from the URL — same effect, no foot-gun).
- **`--fail`**: a 404 / 5xx from GitHub no longer silently writes an HTML error page that then gets `chmod +x`'d.
- **#12**: actual integrity verification. `set -e` at the top of `install.sh` means a mismatch aborts before `sudo install` runs.

The verification only runs when `install.sh` just downloaded the binary — if a local `ussher` already exists (the `./build.sh && ./install.sh` build-from-source flow), the script trusts it and skips both downloads. That keeps the local-build flow working without a sidecar `.sha256` file. The trust model there is "you built it yourself", which is fine.

### `README.md`

The "Recommended installation & usage" step 1 now shows the parallel curl + `sha256sum -c` commands for adopters who skip `install.sh` and follow the README manually. The "don't proceed past this step on a mismatch" instruction is called out explicitly.

## Test plan

- [x] `shellcheck install.sh build.sh` passes (the existing CI job from #6/#7 will also catch this on the PR).
- [x] Local dry-run of the new sequence: `./build.sh` produces `ussher`; `sha256sum ussher > ussher.sha256` followed by `sha256sum -c ussher.sha256` round-trips cleanly.
- [x] `./build.sh` still green; tests pass; coverage unchanged at 39.5%.
- [x] CI shellcheck + build jobs both green on the PR.
- [ ] (post-merge) First tag push produces both `ussher` and `ussher.sha256` as release assets; the README quickstart steps run end-to-end against that release.

## Out of scope (follow-ups)

- **`.goreleaser.yml`** for cross-compiled binaries and Cosign signing — pairs with #15 and is a strictly bigger scope. The lines this PR adds will be replaced wholesale if/when goreleaser lands; this PR is a strict improvement on the current state in the meantime.
- **A behavioral CI test of `install.sh`**'s download block (the test plan I sketched on #1's comment thread). Worth adding but widens scope; happy to do it as its own PR if you want.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47

---
_Generated by [Claude Code](https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47)_