### PR TITLE
Add CHANGELOG.md and use it as the release body (closes #17)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,7 +57,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/v')
       with:
-        body_path: README.md
+        body_path: CHANGELOG.md
         files: |
           ussher
           ussher.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to `ussher` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Configurable disk-cache TTL via the `cache_ttl` field in
+  `/etc/ussher/<user>.yml`, parsed by `time.ParseDuration` (`30s`, `5m`, `1h`).
+  Defaults to `5m` when unset. ([#3], [#8])
+- A `sha256` checksum of the release binary is now published as a release
+  asset alongside the binary itself, and `install.sh` verifies it before
+  proceeding. The README quickstart shows the same verification commands for
+  adopters following the manual install path. ([#12], [#25])
+- CI job that lints every tracked shell script with `shellcheck`. ([#6], [#7])
+
+### Changed
+
+- `install.sh` now downloads the binary with `curl -fLO` (was `curl -L -o`)
+  and refuses to proceed if the published `sha256` doesn't match. `--fail`
+  ensures HTTP errors no longer silently produce an installable HTML error
+  page. ([#1], [#12], [#25])
+
+### Fixed
+
+- HTTP fetch errors in `GetURL` and `GetGHE` no longer terminate the process.
+  Previously `log.Fatal` calls inside the per-source goroutine killed the
+  entire `ussher` invocation on the first source failure, dropping authorized
+  keys produced by every other healthy source. Errors are now logged and the
+  failing source contributes zero keys. ([#2], [#10])
+
+### Security
+
+- Cached upstream responses now expire after `cache_ttl`. Previously the
+  cache had no expiry, so a key revoked on the upstream
+  (`github.com/<user>.keys`, etc.) would continue to authenticate indefinitely
+  until `/var/cache/ussher` was manually cleared. ([#3], [#8])
+
+## [1.0.2] - 2023-04-30
+
+### Security
+
+- Fixed the `isExecutableWritable` startup gate to actually detect group- and
+  world-writable executables. The previous mask checked the wrong bit
+  positions (owner-read at `1<<7` and the sticky-bit area at `1<<9` instead
+  of group-write `0o020` and other-write `0o002`), so the gate would silently
+  pass binaries it was meant to refuse.
+
+## [1.0.1] - 2023-04-29
+
+### Changed
+
+- Re-licensed under Apache 2.0.
+- `install.sh` now downloads the prebuilt binary from the latest release
+  instead of building from source.
+
+### Fixed
+
+- Corrected an incorrect `authorized_keys` path in the README.
+
+## [1.0.0] - 2023-04-27
+
+Initial release.
+
+[Unreleased]: https://github.com/dolph/ussher/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/dolph/ussher/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/dolph/ussher/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/dolph/ussher/releases/tag/v1.0.0
+
+[#1]: https://github.com/dolph/ussher/issues/1
+[#2]: https://github.com/dolph/ussher/issues/2
+[#3]: https://github.com/dolph/ussher/issues/3
+[#6]: https://github.com/dolph/ussher/pull/6
+[#7]: https://github.com/dolph/ussher/pull/7
+[#8]: https://github.com/dolph/ussher/pull/8
+[#10]: https://github.com/dolph/ussher/pull/10
+[#12]: https://github.com/dolph/ussher/issues/12
+[#25]: https://github.com/dolph/ussher/pull/25

--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ AuthorizedKeysCommand /usr/local/bin/ussher
 
 The user specified to `ussher` is either not a valid Linux username or not an existing user on the host. Double check the username specified to `ussher` as well as the `AuthorizedKeysCommand` value in `/etc/ssh/sshd_config`.
 
+## Changelog
+
+See [`CHANGELOG.md`](./CHANGELOG.md) for the per-release history. The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to [Semantic Versioning](https://semver.org/).
+
 ## License
 
 Apache 2.0


### PR DESCRIPTION
Closes #17.

## Summary

Adds a hand-curated `CHANGELOG.md` covering v1.0.0–v1.0.2 reconstructed from the git history, plus an `[Unreleased]` section for the work merged on `main` since v1.0.2. The release workflow now uses `CHANGELOG.md` as the release body instead of the project README — so adopters reading "what changed in v1.4 vs v1.3?" on a release page actually get an answer.

## Why this shape

[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) is the closest thing to an industry-standard format for hand-curated release notes — categorized (Added / Changed / Deprecated / Removed / Fixed / Security), reverse-chronological, dated, with comparison links between releases. It's better than auto-generated PR-title release notes (`generate_release_notes: true`) for a security-sensitive tool because every change gets a deliberate human-readable line that says *what* and *why*, rather than the PR title du jour. The `[Unreleased]` section keeps an always-current preview of what the next tag will contain, which is the discipline that keeps the file from rotting.

## Reconstructed history

| Tag | Date | Highlights |
|---|---|---|
| **v1.0.0** | 2023-04-27 | Initial release. |
| **v1.0.1** | 2023-04-29 | Apache 2.0 re-license; `install.sh` switched from build-from-source to download-prebuilt; README path fix. |
| **v1.0.2** | 2023-04-30 | **Security**: fixed `isExecutableWritable` — the previous mask was checking owner-read (`1<<7`) and the sticky-bit area (`1<<9`) instead of group-write (`0o020`) and other-write (`0o002`), so the gate was a no-op against the bits its name claims to refuse. |

The companion `just use constants` commit (68af9c7) is a readability rewrite of the same lines and isn't called out separately — it's part of the same release.

## `[Unreleased]` section

Captures the post-v1.0.2 main-branch work, categorized:

- **Added**: configurable `cache_ttl` (#3, #8); `sha256` release-asset publication + verification (#12, #25); shellcheck CI (#6, #7).
- **Changed**: `install.sh` rewritten with working `curl -fLO` + `--fail` + checksum verification (#1, #12, #25).
- **Fixed**: `log.Fatal` no longer kills the process on HTTP errors (#2, #10).
- **Security**: cache entries now expire — revoked keys actually stop authenticating (#3, #8).

## Workflow change

```diff
- body_path: README.md
+ body_path: CHANGELOG.md
```

That's the entire release-body change. Combined with the hand-curated content, it directly resolves #17 (release body hard-coded to README.md).

## README

Adds a small "Changelog" section pointing at the file and noting the Keep-a-Changelog + SemVer commitments.

## Going-forward discipline

Every PR with adopter-visible behavior should add a bullet under `[Unreleased]` in the appropriate category. At release time, `[Unreleased]` gets renamed to the new version with the release date, and a fresh empty `[Unreleased]` is added at the top. (Worth capturing in `CONTRIBUTING.md` if/when that lands — separate scope.)

## Test plan

- [x] `./build.sh` green; tests still pass; coverage unchanged at 39.5% (no source change).
- [x] `shellcheck install.sh build.sh` green.
- [x] `CHANGELOG.md` renders cleanly as Markdown; reference-style links resolve.
- [x] CI shellcheck + build jobs both green on the PR.
- [ ] (post-merge, once a tag fires) GitHub release page shows the CHANGELOG content as the body.

## Out of scope

- **Backfilling existing release pages.** GitHub releases for v1.0.0–v1.0.2 already exist with whatever body they were created with (currently the README content per the old workflow). The release body is independent of the source CHANGELOG; updating those pages is a one-shot UI / API edit. Happy to do it — say the word and I'll patch each release body via the GitHub API to match the corresponding `CHANGELOG.md` section.
- **Automated changelog generation** (`release-please`, `git-cliff`, etc.). Hand-curated is the right fit for a security-sensitive tool at this size; revisit if PR volume grows.
- **Auto-generated GitHub release notes** as a *supplement* (`generate_release_notes: true` in addition to `body_path`). softprops/action-gh-release v1 doesn't merge them with a body_path; choosing one. Hand-curated wins here.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47

---
_Generated by [Claude Code](https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47)_