### PR TITLE
Cut v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-27
+
 ### Added
 
 - Configurable disk-cache TTL via the `cache_ttl` field in
@@ -66,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
-[Unreleased]: https://github.com/dolph/ussher/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/dolph/ussher/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/dolph/ussher/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/dolph/ussher/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/dolph/ussher/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/dolph/ussher/releases/tag/v1.0.0


### PR DESCRIPTION
Promotes the `[Unreleased]` section in `CHANGELOG.md` to `[1.1.0] - 2026-04-27` and adds a fresh empty `[Unreleased]` above it. Updates the compare-link footnotes so `[Unreleased]` now compares `HEAD` against `v1.1.0` and the new `[1.1.0]` entry compares `v1.0.2...v1.1.0`.

## Why 1.1.0 (not 1.0.3 or 2.0.0)

Per [SemVer](https://semver.org), this is a **MINOR** bump from `1.0.x`:

- **Added** `cache_ttl` config field — backwards-compatible (omitting it preserves the new default behavior).
- **Security** change behavior — cache entries now expire (previously: never). This is the *intent* of fixing #3 and is the right opt-out-not-opt-in default for a tool in the authentication path; defaulting to `cache_ttl: 0` (= retain old behavior) would have shipped the security bug forever. Operators who actively want the old behavior can set `cache_ttl` to something very large.
- No public API removed; no breaking source-level change.

A 1.0.3 PATCH bump would understate the new feature (`cache_ttl`); a 2.0.0 MAJOR bump would overstate the disruption (no API was removed, just runtime behavior tightened in the security-correct direction).

## v1.1.0 contents

Already populated in `[Unreleased]` before this PR — this commit just renames the heading and updates compare links.

- **Added**: `cache_ttl` config field; `sha256` release-asset publication and `install.sh` verification; shellcheck CI.
- **Changed**: `install.sh` download path uses `curl -fLO` + checksum verification.
- **Fixed**: HTTP fetch errors no longer terminate the process.
- **Security**: cache entries now expire so revoked keys actually stop authenticating.

## What happens after this merges

The release workflow (`.github/workflows/go.yml`) triggers on `tags: v*`. Once this PR is on `main`, push the `v1.1.0` tag — the workflow builds, generates `ussher.sha256`, and uploads both as `v1.1.0` release assets with `CHANGELOG.md` as the release body. CLI for that step is in the chat reply that opened this PR.

## Test plan

- [x] CHANGELOG renders cleanly; compare links resolve (will be live once the tag exists).
- [x] CI shellcheck + build jobs both green on the PR.
- [ ] (post-merge) `git push origin v1.1.0` runs the release workflow, which produces both `ussher` and `ussher.sha256` on the v1.1.0 release page with the CHANGELOG as body.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47

---
_Generated by [Claude Code](https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47)_