### PR TITLE
Add configurable http_timeout so a hung upstream can't block sshd auth (closes #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable disk-cache TTL via the `cache_ttl` field in
   `/etc/ussher/<user>.yml`, parsed by `time.ParseDuration` (`30s`, `5m`, `1h`).
   Defaults to `5m` when unset. ([#3], [#8])
+- Configurable per-request HTTP timeout via the `http_timeout` field, parsed
+  by `time.ParseDuration` (`500ms`, `10s`, `30s`). Defaults to `10s` when
+  unset. ([#31])
 - A `sha256` checksum of the release binary is now published as a release
   asset alongside the binary itself, and `install.sh` verifies it before
   proceeding. The README quickstart shows the same verification commands for
@@ -32,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entire `ussher` invocation on the first source failure, dropping authorized
   keys produced by every other healthy source. Errors are now logged and the
   failing source contributes zero keys. ([#2], [#10])
+- `http.Client` now has a default 10s timeout, so a hung or stalled upstream
+  source can no longer block `sshd`'s authentication path indefinitely.
+  Previously a misbehaving source (DNS that resolved but never responded, a
+  TLS handshake that hung, etc.) would stall `Run`'s `WaitGroup` until the
+  OS-default TCP timeout (often minutes) and `sshd` would block waiting for
+  `ussher` for that entire duration. Operators can override the default via
+  the `http_timeout` config field. ([#31])
 
 ### Security
 
@@ -80,3 +90,4 @@ Initial release.
 [#10]: https://github.com/dolph/ussher/pull/10
 [#12]: https://github.com/dolph/ussher/issues/12
 [#25]: https://github.com/dolph/ussher/pull/25
+[#31]: https://github.com/dolph/ussher/issues/31

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ sources:
 - url: https://github.com/dolph.keys
 ```
 
+### `http_timeout`
+
+`http_timeout` caps how long a single upstream fetch (connect + headers + body read) can take before `ussher` gives up on it. A hung or stalled source — DNS that resolves but never returns, a TLS handshake that hangs, an HTTP server that accepts the connection but never responds — would otherwise block `sshd`'s authentication path until the OS-default timeout fires (often 2+ minutes per attempt). With `http_timeout`, `ussher` abandons the source quickly, treats the failure exactly like any other (logs and contributes zero keys from that source), and the rest of the configured sources continue to be served.
+
+`http_timeout` accepts any duration string understood by [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) — for example `500ms`, `10s`, `30s`. The default when unset is `10s`. Tighter values trade a higher rate of "slow but healthy upstream gave up" denials for tighter login latency under partial outages; looser values do the opposite.
+
+```yaml
+http_timeout: 10s
+sources:
+- url: https://github.com/dolph.keys
+```
+
 ## Troubleshooting
 
 ### `Refusing to run unnecessarily writable binary`

--- a/cmd.go
+++ b/cmd.go
@@ -8,7 +8,7 @@ import (
 func Run(c *Config) {
 	var wg sync.WaitGroup
 
-	client := NewHTTPClient(c.ResolveCacheTTL())
+	client := NewHTTPClient(c.ResolveCacheTTL(), c.ResolveHTTPTimeout())
 	keyChan := make(chan []string)
 	for _, source := range c.Sources {
 		wg.Add(1)

--- a/config.go
+++ b/config.go
@@ -8,7 +8,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const defaultCacheTTL = 5 * time.Minute
+const (
+	defaultCacheTTL     = 5 * time.Minute
+	defaultHTTPTimeout  = 10 * time.Second
+)
 
 type GithubEnterprise struct {
 	Hostname string `yaml:"api_hostname"`
@@ -23,8 +26,12 @@ type Source struct {
 type Config struct {
 	// CacheTTL is parsed by time.ParseDuration ("5m", "30s", "1h"). An empty
 	// or unparseable value falls back to defaultCacheTTL.
-	CacheTTL string   `yaml:"cache_ttl"`
-	Sources  []Source `yaml:"sources"`
+	CacheTTL string `yaml:"cache_ttl"`
+	// HTTPTimeout caps how long a single upstream fetch (connect + headers +
+	// body read) can take before it's abandoned. Parsed by time.ParseDuration.
+	// An empty or unparseable value falls back to defaultHTTPTimeout.
+	HTTPTimeout string   `yaml:"http_timeout"`
+	Sources     []Source `yaml:"sources"`
 }
 
 // ResolveCacheTTL returns the configured cache TTL, falling back to a sane
@@ -37,6 +44,20 @@ func (c *Config) ResolveCacheTTL() time.Duration {
 	if err != nil {
 		log.Printf("Invalid cache_ttl %q, falling back to %s: %v", c.CacheTTL, defaultCacheTTL, err)
 		return defaultCacheTTL
+	}
+	return d
+}
+
+// ResolveHTTPTimeout returns the configured per-request HTTP timeout,
+// falling back to a sane default when unset or malformed.
+func (c *Config) ResolveHTTPTimeout() time.Duration {
+	if c.HTTPTimeout == "" {
+		return defaultHTTPTimeout
+	}
+	d, err := time.ParseDuration(c.HTTPTimeout)
+	if err != nil {
+		log.Printf("Invalid http_timeout %q, falling back to %s: %v", c.HTTPTimeout, defaultHTTPTimeout, err)
+		return defaultHTTPTimeout
 	}
 	return d
 }

--- a/config_test.go
+++ b/config_test.go
@@ -116,3 +116,45 @@ sources:
 		t.Errorf("ResolveCacheTTL() = %v, want %v", got, 15*time.Minute)
 	}
 }
+
+func TestResolveHTTPTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{"empty falls back to default", "", defaultHTTPTimeout},
+		{"unparseable falls back to default", "ten seconds", defaultHTTPTimeout},
+		{"valid milliseconds", "500ms", 500 * time.Millisecond},
+		{"valid seconds", "30s", 30 * time.Second},
+		{"valid minutes", "2m", 2 * time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{HTTPTimeout: tc.raw}
+			if got := c.ResolveHTTPTimeout(); got != tc.want {
+				t.Errorf("ResolveHTTPTimeout() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfigLoadHTTPTimeout(t *testing.T) {
+	yamlContent := `
+http_timeout: 5s
+sources:
+- url: https://example.com/keys
+`
+	tmpFile, cleanup := createTempConfig(t, yamlContent)
+	defer cleanup()
+
+	config := &Config{}
+	config.LoadConfigByPath(tmpFile)
+
+	if config.HTTPTimeout != "5s" {
+		t.Errorf("Expected HTTPTimeout %q, got %q", "5s", config.HTTPTimeout)
+	}
+	if got := config.ResolveHTTPTimeout(); got != 5*time.Second {
+		t.Errorf("ResolveHTTPTimeout() = %v, want %v", got, 5*time.Second)
+	}
+}

--- a/httpclient.go
+++ b/httpclient.go
@@ -18,9 +18,11 @@ type Client struct {
 	ttl   time.Duration
 }
 
-func NewHTTPClient(ttl time.Duration) *Client {
+func NewHTTPClient(ttl, httpTimeout time.Duration) *Client {
 	return &Client{
-		http:  &http.Client{},
+		http: &http.Client{
+			Timeout: httpTimeout,
+		},
 		cache: NewCache("/var/cache/ussher"),
 		ttl:   ttl,
 	}

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -103,6 +103,43 @@ func TestGetURL_UnreachableIsNotFatal(t *testing.T) {
 	}
 }
 
+func TestGetURL_TimeoutIsNotFatal(t *testing.T) {
+	// Server that accepts the connection but stalls before responding,
+	// simulating a hung upstream. Without http.Client.Timeout the test would
+	// hang for the OS-default; with a tight timeout the client must give up
+	// promptly and GetURL must return empty (not panic, not log.Fatal).
+	released := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-released
+	}))
+	defer func() {
+		close(released)
+		srv.Close()
+	}()
+
+	timeout := 100 * time.Millisecond
+	c, cleanup := newTestClient(t, &http.Client{Timeout: timeout})
+	defer cleanup()
+
+	start := time.Now()
+	keys := c.GetURL(srv.URL)
+	elapsed := time.Since(start)
+
+	if len(keys) != 0 {
+		t.Errorf("want empty slice on timeout, got %v", keys)
+	}
+	if elapsed > 5*timeout {
+		t.Errorf("expected timeout to fire near %s, took %s", timeout, elapsed)
+	}
+}
+
+func TestNewHTTPClient_PropagatesTimeout(t *testing.T) {
+	c := NewHTTPClient(time.Minute, 7*time.Second)
+	if got := c.http.Timeout; got != 7*time.Second {
+		t.Errorf("NewHTTPClient http.Timeout = %s, want 7s", got)
+	}
+}
+
 func TestGetGHE_UnreachableIsNotFatal(t *testing.T) {
 	c, cleanup := newTestClient(t, &http.Client{Timeout: 2 * time.Second})
 	defer cleanup()


### PR DESCRIPTION
Closes #31.

## Summary

Adds a global `http_timeout` config field defaulting to `10s` and propagates it to `http.Client.Timeout` so that a hung or stalled upstream can no longer block `sshd`'s authentication path.

## Why

`NewHTTPClient` previously constructed `&http.Client{}` with no `Timeout`. A misbehaving upstream — DNS that resolves but never responds, TLS handshake that hangs, slowloris-style server, anyone with control over a configured source URL — would block the per-source goroutine until the OS-default TCP timeout (typically several minutes). `cmd.go:Run` waits on every per-source goroutine via `wg.Wait()` before closing the `keyChan`, so one stalled source stalls the entire login. PR #10 made HTTP *errors* non-fatal, but a request that never returns isn't an error — it's just hung.

A timeout firing produces the same error class PR #10 already handles: `GetURL` logs `Failed to fetch ...: context deadline exceeded ...` and returns an empty slice. The source quietly contributes zero keys; healthy sources keep producing keys; the rest of the login proceeds normally.

## Behavior

| Config | Behavior |
|---|---|
| omitted | 10s default |
| `http_timeout: 30s` | 30s |
| `http_timeout: garbage` | logs warning, falls back to 10s |
| `http_timeout: 0s` | no timeout (Go semantics — operators who want this can opt in explicitly) |

The default of 10s trades a modest "slow but healthy upstream gave up" risk for tight bounds on auth-path latency under partial outages. For a tool sshd consults synchronously on every login that's the right trade; operators wanting different bounds can tune it.

## Diff shape

- `config.go`: add `HTTPTimeout string` field, `defaultHTTPTimeout = 10 * time.Second`, and `ResolveHTTPTimeout()` mirroring `ResolveCacheTTL`.
- `httpclient.go`: `NewHTTPClient` now takes `(ttl, httpTimeout time.Duration)` and sets `http.Client.Timeout`.
- `cmd.go`: passes `c.ResolveHTTPTimeout()` through.
- `README.md`: parallel `http_timeout` section under Configuration, framing the latency-vs-tolerance trade-off.
- `CHANGELOG.md`: bullets in `[Unreleased]` under Added (the new field) and Fixed (the underlying availability bug).

## Tests

- `TestNewHTTPClient_PropagatesTimeout` — wiring assertion that the constructor's `httpTimeout` lands on `http.Client.Timeout`.
- `TestGetURL_TimeoutIsNotFatal` — behavioral test using a server that stalls before responding; verifies `GetURL` returns an empty slice within ~timeout (not the OS-default), so a hung server can't block the test process either.
- `TestResolveHTTPTimeout` — table-driven: empty / unparseable fall back to default; valid `500ms` / `30s` / `2m` parse correctly.
- `TestConfigLoadHTTPTimeout` — `http_timeout: 5s` round-trips through YAML and resolves to `5 * time.Second`.

All run under `-race` (issue #16 isn't fixed yet, but I ran the suite locally with `go test -race`). Coverage 39.5% → 42.1%.

## Out of scope (call out, don't widen)

- **Per-source `http_timeout`** — mirrors the `cache_ttl` per-source proposal in #9. Worth a sibling design if/when that lands; deliberately not in this PR per the issue's "global" scope.
- **Stale-on-error fallback (#11)** — a timeout firing is exactly the kind of "fetch failure" that #11 would want to fall back on stale cached keys for. Their interaction is clean: this PR makes the failure happen *fast*; #11 makes the user not feel it. Good follow-up.

## Test plan

- [x] `./build.sh` green; coverage 42.1%.
- [x] `go test -race ./...` green.
- [x] `TestGetURL_TimeoutIsNotFatal` completes in ~100ms (the configured timeout) — no hang.
- [ ] CI shellcheck + build jobs both green on the PR.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47

---
_Generated by [Claude Code](https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47)_