### PR TITLE
Fix main() panicking on os.Args[1] when invoked with no arguments (closes #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ussher` invoked with no arguments now prints `usage: ussher <username>`
+  and exits cleanly instead of panicking with a Go runtime "index out of
+  range" trace. The argument-count check used to live below the
+  `os.Args[1] == "--version"` access, making the bare-invocation case
+  unreachable. ([#29])
+
 ## [1.1.0] - 2026-04-27
 
 ### Added
@@ -93,4 +101,5 @@ Initial release.
 [#10]: https://github.com/dolph/ussher/pull/10
 [#12]: https://github.com/dolph/ussher/issues/12
 [#25]: https://github.com/dolph/ussher/pull/25
+[#29]: https://github.com/dolph/ussher/issues/29
 [#31]: https://github.com/dolph/ussher/issues/31

--- a/ussher.go
+++ b/ussher.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 )
@@ -24,10 +25,26 @@ func initLog() {
 	log.SetOutput(file)
 }
 
+// validateArgs requires args to look like `ussher <single-arg>` (a username
+// or `--version`) and returns the single arg or a usage error. The wrong-arg-
+// count check has to live before any os.Args[1] access; otherwise invoking
+// `ussher` with no args panics with "index out of range".
+func validateArgs(args []string) (string, error) {
+	if len(args) != 2 {
+		return "", errors.New("usage: ussher <username>")
+	}
+	return args[1], nil
+}
+
 func main() {
+	arg, err := validateArgs(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Support `ussher --version` to print versioning info about the executable
 	// before proceeding to security-hardening checks.
-	if os.Args[1] == "--version" {
+	if arg == "--version" {
 		PrintVersion()
 		return
 	}
@@ -44,13 +61,8 @@ func main() {
 	// a non-root user
 	initLog()
 
-	// Check if the input username is provided
-	if len(os.Args) != 2 {
-		log.Fatal("usage: ussher <username>")
-	}
-
 	// Check if the input username is valid
-	username := os.Args[1]
+	username := arg
 	if !isValidUser(username) {
 		log.Fatal("User not found")
 	}

--- a/ussher_test.go
+++ b/ussher_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestValidateArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{"no args (just program name)", []string{"ussher"}, "", true},
+		{"empty args slice", []string{}, "", true},
+		{"single arg looks like username", []string{"ussher", "alice"}, "alice", false},
+		{"single arg is --version", []string{"ussher", "--version"}, "--version", false},
+		{"too many args", []string{"ussher", "alice", "extra"}, "", true},
+		{"too many args with --version", []string{"ussher", "--version", "extra"}, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateArgs(tc.args)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateArgs(%v) err = %v, wantErr %v", tc.args, err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("validateArgs(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #29.

## Summary

`./ussher` (no arguments) used to panic with `runtime error: index out of range [1] with length 1` because `main()` accessed `os.Args[1]` on its very first line — the `--version` short-circuit — before the args-count check ten lines further down. The intended `usage: ussher <username>` message was unreachable for the no-args case.

## Fix

Extract `validateArgs(args []string) (string, error)`. It enforces `len(args) == 2` and returns either the single arg (the username, or `--version`) or a typed usage error. `main()` calls it as its very first statement and `log.Fatal`s on error.

```diff
-    if os.Args[1] == "--version" {
+    arg, err := validateArgs(os.Args)
+    if err != nil {
+        log.Fatal(err)
+    }
+    if arg == "--version" {
        PrintVersion()
        return
     }
     ...
-    if len(os.Args) != 2 {
-        log.Fatal("usage: ussher <username>")
-    }
-    username := os.Args[1]
+    username := arg
```

The downstream `len(os.Args) != 2` check is now dead code and removed. The `--version` short-circuit, the security gates, `initLog`, and `isValidUser` sequencing are unchanged. This extraction is also a useful seam for the broader `main()` refactor proposed in #13 — that issue's `parseArgs` would build on this `validateArgs`.

## Tests

New `ussher_test.go` with `TestValidateArgs` covering six cases:

- bare program name (no args) → error
- empty args slice → error
- single arg as username → returns username
- single arg as `--version` → returns `--version`
- too many args (3 with username) → error
- too many args (3 with `--version`) → error

Coverage 42.1% → 42.7%; tests pass under `-race`.

## End-to-end repro

```
$ ./ussher
2026/04/27 20:11:26 usage: ussher <username>
$ echo $?
1
```

(Pre-fix: stack trace + exit 2.)

## Releasing-this-thought

`v1.1.0` is queued in `CHANGELOG.md` but not yet tagged. The new Fixed bullet lives under `[Unreleased]` for safety — if you want this fix in `v1.1.0`, move the bullet into `[1.1.0]` before pushing the tag; otherwise it ships in `1.1.1` / `1.2.0`. Either is fine.

## Test plan

- [x] `./build.sh` green; coverage 42.7%.
- [x] `go test -race ./...` green.
- [x] `./ussher` (no args) prints `usage: ussher <username>` and exits 1 (no panic).
- [x] `./ussher --version` still prints version info.
- [x] `./ussher root` (or any valid user) still proceeds normally.
- [x] `./ussher alice extra` still rejected as wrong-arg-count.
- [ ] CI shellcheck + build jobs both green on the PR.

https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47

---
_Generated by [Claude Code](https://claude.ai/code/session_013HnepY8MhhxrJJjE5ysW47)_