### PR TITLE
fix: check config file is not world-writable before loading

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,6 +70,14 @@ func (c *Config) LoadConfigByUser(username string) {
 }
 
 func (c *Config) LoadConfigByPath(path string) {
+	// Before reading the config file, check that it isn't world-writable.
+	if worldWritable, _ := isFileWorldWritable(path); worldWritable {
+		log.Printf(
+			"Refusing to load configuration from %v: file is world-writable",
+			path,
+		)
+		return
+	}
 	yamlFile, err := os.ReadFile(path)
 	if err != nil {
 		log.Printf("Failed to %v ", err)


### PR DESCRIPTION
## Summary

`LoadConfigByPath` now checks whether the config file is world-writable before reading it, using the existing but unused `isFileWorldWritable` function from `security.go`.

## What changed

Added a world-writable check at the top of `LoadConfigByPath` in `config.go` (8 lines added). If the file is world-writable (or unreadable), the load is skipped and a warning is logged:

```
Refusing to load configuration from /etc/ussher/<user>.yml: file is world-writable
```

This follows the same pattern as other security gates in `ussher.go` (`isExecutableWritable`, `isRunningAsRoot`, `isValidUser`) which all prevent unsafe operation.

## Why

`isFileWorldWritable` was defined in `security.go` but never called anywhere in the codebase. The config file at `/etc/ussher/<user>.yml` controls which URLs ussher fetches SSH keys from — a world-writable config file means an attacker could redirect key lookups.

Fixes #5