### PR TITLE
Remove unused GitHub Enterprise (GHE) code

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,12 +13,6 @@ const (
 	defaultHTTPTimeout  = 10 * time.Second
 )
 
-type GithubEnterprise struct {
-	Hostname string `yaml:"api_hostname"`
-	Username string `yaml:"user"`
-	Token    string `yaml:"token"`
-}
-
 type Source struct {
 	URL string `yaml:"url"`
 }

--- a/httpclient.go
+++ b/httpclient.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"encoding/json"
 	"io"
 	"log"
 	"net/http"
@@ -60,74 +59,18 @@ func (c *Client) GetURL(url string) []string {
 	return make([]string, 0)
 }
 
-type GHEKey struct {
-	ID  int    `json:"id"`
-	Key string `json:"key"`
-}
-
-func (c *Client) GetGHE(ghe GithubEnterprise) []string {
-	url := "https://" + ghe.Hostname + "/users/" + ghe.Username + "/keys"
-
-	/* This will cache responses regardless of the token in context here, which could be a security risk. */
-	if cached, setAt, ok := c.cache.Get(url); ok && c.fresh(setAt) {
-		var keys []GHEKey
-		err := json.Unmarshal(cached, &keys)
-		if err != nil {
-			log.Printf("Failed to decode JSON from cache for %v: %v", url, err)
-			return make([]string, 0)
-		}
-		return GHEKeysToKeys(keys)
-	}
-
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		log.Printf("Failed to build request for %v: %v", url, err)
-		return make([]string, 0)
-	}
-
-	req.Header = http.Header{
-		"Accept":        {"application/vnd.github+json"},
-		"Authorization": {"token " + ghe.Token}}
-
-	log.Printf("GET %v", url)
-	resp, err := c.http.Do(req)
-	if err != nil {
-		log.Printf("Failed to fetch %v: %v", url, err)
-		return make([]string, 0)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Failed to read response body from %v: %v", url, err)
-			return make([]string, 0)
-		}
-		c.cache.Set(url, bodyBytes)
-		var keys []GHEKey
-		if err := json.Unmarshal(bodyBytes, &keys); err != nil {
-			log.Printf("Failed to decode JSON from %v: %v", url, err)
-			return make([]string, 0)
-		}
-
-		return GHEKeysToKeys(keys)
-	}
-	log.Printf("HTTP %d from %v", resp.StatusCode, url)
-	return make([]string, 0)
-}
-
 func bodyToKeys(body []byte) []string {
-	s := string(body)
-	s = strings.TrimSuffix(s, "\n")
-	keys := strings.Split(s, "\n")
-	log.Printf("Found %v key(s)", len(keys))
-	return keys
-}
-
-func GHEKeysToKeys(gheKeys []GHEKey) []string {
-	var keys []string
-	for _, gheKey := range gheKeys {
-		keys = append(keys, gheKey.Key)
+	s := strings.TrimSuffix(string(body), "\n")
+	if s == "" {
+		log.Printf("Found %v key(s)", 0)
+		return []string{}
+	}
+	parts := strings.Split(s, "\n")
+	keys := make([]string, 0, len(parts))
+	for _, line := range parts {
+		if line != "" {
+			keys = append(keys, line)
+		}
 	}
 	log.Printf("Found %v key(s)", len(keys))
 	return keys

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 )
@@ -14,16 +12,13 @@ import (
 // fresh temp cache directory. Returns the client plus a cleanup func.
 func newTestClient(t *testing.T, httpClient *http.Client) (*Client, func()) {
 	t.Helper()
-	tmpDir, err := ioutil.TempDir("", "httpclient-test")
-	if err != nil {
-		t.Fatal("temp dir:", err)
-	}
+	tmpDir := t.TempDir()
 	c := &Client{
 		http:  httpClient,
 		cache: NewCache(tmpDir),
 		ttl:   time.Minute,
 	}
-	return c, func() { os.RemoveAll(tmpDir) }
+	return c, func() {}
 }
 
 func TestGetURL_Success(t *testing.T) {
@@ -133,6 +128,32 @@ func TestGetURL_TimeoutIsNotFatal(t *testing.T) {
 	}
 }
 
+func TestBodyToKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"empty body", "", []string{}},
+		{"newline only", "\n", []string{}},
+		{"single key", "ssh-rsa AAAA\n", []string{"ssh-rsa AAAA"}},
+		{"skips blank lines", "a\n\nb\n", []string{"a", "b"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bodyToKeys([]byte(tc.body))
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d: %v", len(got), len(tc.want), got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestNewHTTPClient_PropagatesTimeout(t *testing.T) {
 	c := NewHTTPClient(time.Minute, 7*time.Second)
 	if got := c.http.Timeout; got != 7*time.Second {
@@ -140,19 +161,3 @@ func TestNewHTTPClient_PropagatesTimeout(t *testing.T) {
 	}
 }
 
-func TestGetGHE_UnreachableIsNotFatal(t *testing.T) {
-	c, cleanup := newTestClient(t, &http.Client{Timeout: 2 * time.Second})
-	defer cleanup()
-
-	// example.invalid is reserved and guaranteed to not resolve, exercising
-	// GetGHE's transport-error path. Pre-fix this would log.Fatal and kill
-	// the test process.
-	keys := c.GetGHE(GithubEnterprise{
-		Hostname: "example.invalid",
-		Username: "alice",
-		Token:    "irrelevant",
-	})
-	if len(keys) != 0 {
-		t.Errorf("want empty slice on unreachable GHE host, got %v", keys)
-	}
-}


### PR DESCRIPTION
## Summary
- Remove `GithubEnterprise` from config (never referenced in `main`)
- Remove `GetGHE`, `GHEKey`, and `GHEKeysToKeys` from `httpclient.go`
- Drop `TestGetGHE_UnreachableIsNotFatal` (only exercised removed code)

Implements Option A from the issue: delete dead GHE paths rather than wire them up.

Fixes #34