### PR TITLE
chore: add Dependabot for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for weekly `gomod` and `github-actions` updates

Pairs with pinned-by-SHA Actions (#22) so dependency bumps arrive as reviewable PRs.

Fixes #18