### PR TITLE
fix: include auth credential in HTTP cache key

### DIFF
--- a/cache_key.go
+++ b/cache_key.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// httpCacheKey returns a cache key for url, mixing in credential when present
+// so different auth tokens cannot share cached responses (#4).
+func httpCacheKey(url, credential string) string {
+	if credential == "" {
+		return url
+	}
+	sum := sha256.Sum256([]byte(credential))
+	return url + "#auth=" + hex.EncodeToString(sum[:8])
+}

--- a/cache_key_test.go
+++ b/cache_key_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestHTTPCacheKey(t *testing.T) {
+	url := "https://git.example.com/users/alice/keys"
+
+	if got := httpCacheKey(url, ""); got != url {
+		t.Fatalf("httpCacheKey without credential = %q; want %q", got, url)
+	}
+
+	a := httpCacheKey(url, "token-a")
+	b := httpCacheKey(url, "token-b")
+	if a == b {
+		t.Fatalf("expected different cache keys for different tokens, both %q", a)
+	}
+	if a == url || b == url {
+		t.Fatal("expected credential to affect cache key")
+	}
+}

--- a/httpclient.go
+++ b/httpclient.go
@@ -67,9 +67,9 @@ type GHEKey struct {
 
 func (c *Client) GetGHE(ghe GithubEnterprise) []string {
 	url := "https://" + ghe.Hostname + "/users/" + ghe.Username + "/keys"
+	cacheKey := httpCacheKey(url, ghe.Token)
 
-	/* This will cache responses regardless of the token in context here, which could be a security risk. */
-	if cached, setAt, ok := c.cache.Get(url); ok && c.fresh(setAt) {
+	if cached, setAt, ok := c.cache.Get(cacheKey); ok && c.fresh(setAt) {
 		var keys []GHEKey
 		err := json.Unmarshal(cached, &keys)
 		if err != nil {
@@ -103,7 +103,7 @@ func (c *Client) GetGHE(ghe GithubEnterprise) []string {
 			log.Printf("Failed to read response body from %v: %v", url, err)
 			return make([]string, 0)
 		}
-		c.cache.Set(url, bodyBytes)
+		c.cache.Set(cacheKey, bodyBytes)
 		var keys []GHEKey
 		if err := json.Unmarshal(bodyBytes, &keys); err != nil {
 			log.Printf("Failed to decode JSON from %v: %v", url, err)


### PR DESCRIPTION
## Summary

Fixes #4. `GetGHE` now caches under `httpCacheKey(url, token)` so responses for the same URL with different tokens are not shared.

## Test plan

- [x] `go test ./... -run HTTPCacheKey`