### PR TITLE
feat: serve stale cached keys when upstream fetch fails

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -8,7 +8,7 @@ import (
 func Run(c *Config) {
 	var wg sync.WaitGroup
 
-	client := NewHTTPClient(c.ResolveCacheTTL(), c.ResolveHTTPTimeout())
+	client := NewHTTPClient(c.ResolveCacheTTL(), c.ResolveStaleTTL(), c.ResolveHTTPTimeout())
 	keyChan := make(chan []string)
 	for _, source := range c.Sources {
 		wg.Add(1)

--- a/config.go
+++ b/config.go
@@ -27,6 +27,9 @@ type Config struct {
 	// CacheTTL is parsed by time.ParseDuration ("5m", "30s", "1h"). An empty
 	// or unparseable value falls back to defaultCacheTTL.
 	CacheTTL string `yaml:"cache_ttl"`
+	// StaleTTL extends how long a cache entry may be served after cache_ttl
+	// when the upstream fetch fails. Zero disables stale serving.
+	StaleTTL string `yaml:"stale_ttl"`
 	// HTTPTimeout caps how long a single upstream fetch (connect + headers +
 	// body read) can take before it's abandoned. Parsed by time.ParseDuration.
 	// An empty or unparseable value falls back to defaultHTTPTimeout.
@@ -50,6 +53,25 @@ func (c *Config) ResolveCacheTTL() time.Duration {
 
 // ResolveHTTPTimeout returns the configured per-request HTTP timeout,
 // falling back to a sane default when unset or malformed.
+
+// ResolveStaleTTL returns how long beyond cache_ttl stale entries may be served
+// when upstream fetches fail. Zero disables stale serving.
+func (c *Config) ResolveStaleTTL() time.Duration {
+	if c.StaleTTL == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(c.StaleTTL)
+	if err != nil {
+		log.Printf("Invalid stale_ttl %q, disabling stale cache: %v", c.StaleTTL, err)
+		return 0
+	}
+	if d < 0 {
+		log.Printf("Invalid stale_ttl %v, disabling stale cache", d)
+		return 0
+	}
+	return d
+}
+
 func (c *Config) ResolveHTTPTimeout() time.Duration {
 	if c.HTTPTimeout == "" {
 		return defaultHTTPTimeout

--- a/config_test.go
+++ b/config_test.go
@@ -158,3 +158,24 @@ sources:
 		t.Errorf("ResolveHTTPTimeout() = %v, want %v", got, 5*time.Second)
 	}
 }
+
+
+func TestResolveStaleTTL(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "empty disables", raw: "", want: 0},
+		{name: "one hour", raw: "1h", want: time.Hour},
+		{name: "invalid disables", raw: "nope", want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{StaleTTL: tc.raw}
+			if got := c.ResolveStaleTTL(); got != tc.want {
+				t.Fatalf("ResolveStaleTTL() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/httpclient.go
+++ b/httpclient.go
@@ -13,29 +13,40 @@ import (
 )
 
 type Client struct {
-	http  *http.Client
-	cache *Cache
-	ttl   time.Duration
+	http      *http.Client
+	cache     *Cache
+	ttl       time.Duration
+	staleTTL  time.Duration
 }
 
-func NewHTTPClient(ttl, httpTimeout time.Duration) *Client {
+func NewHTTPClient(ttl, staleTTL, httpTimeout time.Duration) *Client {
 	return &Client{
 		http: &http.Client{
 			Timeout: httpTimeout,
 		},
-		cache: NewCache("/var/cache/ussher"),
-		ttl:   ttl,
+		cache:    NewCache("/var/cache/ussher"),
+		ttl:      ttl,
+		staleTTL: staleTTL,
 	}
 }
 
 // fresh reports whether a cached entry written at setAt is still within the
 // configured TTL.
+
+func (c *Client) staleFresh(setAt time.Time) bool {
+	if c.staleTTL <= 0 {
+		return false
+	}
+	return time.Since(setAt) < c.ttl+c.staleTTL
+}
+
 func (c *Client) fresh(setAt time.Time) bool {
 	return time.Since(setAt) < c.ttl
 }
 
 func (c *Client) GetURL(url string) []string {
-	if cached, setAt, ok := c.cache.Get(url); ok && c.fresh(setAt) {
+	cached, setAt, ok := c.cache.Get(url)
+	if ok && c.fresh(setAt) {
 		return bodyToKeys(cached)
 	}
 
@@ -43,6 +54,10 @@ func (c *Client) GetURL(url string) []string {
 	resp, err := c.http.Get(url)
 	if err != nil {
 		log.Printf("Failed to fetch %v: %v", url, err)
+		if ok && c.staleFresh(setAt) {
+			log.Printf("Serving stale cache for %v after fetch error", url)
+			return bodyToKeys(cached)
+		}
 		return make([]string, 0)
 	}
 	defer resp.Body.Close()
@@ -51,12 +66,20 @@ func (c *Client) GetURL(url string) []string {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response body from %v: %v", url, err)
+			if ok && c.staleFresh(setAt) {
+				log.Printf("Serving stale cache for %v after read error", url)
+				return bodyToKeys(cached)
+			}
 			return make([]string, 0)
 		}
 		c.cache.Set(url, bodyBytes)
 		return bodyToKeys(bodyBytes)
 	}
 	log.Printf("HTTP %d from %v", resp.StatusCode, url)
+	if ok && c.staleFresh(setAt) {
+		log.Printf("Serving stale cache for %v after HTTP %d", url, resp.StatusCode)
+		return bodyToKeys(cached)
+	}
 	return make([]string, 0)
 }
 

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -134,7 +134,7 @@ func TestGetURL_TimeoutIsNotFatal(t *testing.T) {
 }
 
 func TestNewHTTPClient_PropagatesTimeout(t *testing.T) {
-	c := NewHTTPClient(time.Minute, 7*time.Second)
+	c := NewHTTPClient(time.Minute, 0, 7*time.Second)
 	if got := c.http.Timeout; got != 7*time.Second {
 		t.Errorf("NewHTTPClient http.Timeout = %s, want 7s", got)
 	}
@@ -154,5 +154,25 @@ func TestGetGHE_UnreachableIsNotFatal(t *testing.T) {
 	})
 	if len(keys) != 0 {
 		t.Errorf("want empty slice on unreachable GHE host, got %v", keys)
+	}
+}
+
+
+func TestClientStaleFresh(t *testing.T) {
+	c := &Client{ttl: time.Minute, staleTTL: time.Hour}
+	freshAt := time.Now().Add(-30 * time.Second)
+	if !c.fresh(freshAt) {
+		t.Fatal("expected entry within cache_ttl to be fresh")
+	}
+	staleAt := time.Now().Add(-2 * time.Minute)
+	if c.fresh(staleAt) {
+		t.Fatal("expected entry past cache_ttl not to be fresh")
+	}
+	if !c.staleFresh(staleAt) {
+		t.Fatal("expected entry within stale_ttl extension to be staleFresh")
+	}
+	tooOld := time.Now().Add(-2 * time.Hour)
+	if c.staleFresh(tooOld) {
+		t.Fatal("expected entry past stale window not to be staleFresh")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #11. Adds `stale_ttl` in config. When an upstream GET fails (network error, non-200, or body read error), ussher serves the cached response if it is still within `cache_ttl + stale_ttl`.

## Test plan

- [x] `go test ./...`